### PR TITLE
Fix docker : test were not launched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,31 +6,17 @@ RUN apt-get update && apt-get install -y \
         libzip-dev \
         zip 
 
-RUN docker-php-ext-configure zip --with-libzip \
-        && docker-php-ext-install zip \
-        && docker-php-ext-enable zip
+RUN docker-php-ext-configure zip --with-libzip
 
-RUN docker-php-ext-install pcntl &&  docker-php-ext-enable pcntl
-RUN docker-php-ext-install gd &&  docker-php-ext-enable gd
+RUN docker-php-ext-install pcntl gd zip \
+	&& docker-php-ext-enable pcntl gd zip
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
-ENV COMPOSER_VERSION 1.7.2
+ENV COMPOSER_VERSION 1.7.3
 
-RUN curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://raw.githubusercontent.com/composer/getcomposer.org/b107d959a5924af895807021fcef4ffec5a76aa9/web/installer \
-        && php -r " \
-                \$signature = '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061'; \
-                \$hash = hash('SHA384', file_get_contents('/tmp/installer.php')); \
-                if (!hash_equals(\$signature, \$hash)) { \
-                        unlink('/tmp/installer.php'); \
-                        echo 'Integrity check failed, installer is either corrupt or worse.' . PHP_EOL; \
-                        exit(1); \
-                }" \
-        && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer --version=${COMPOSER_VERSION} \
-        && composer --ansi --version --no-interaction \
-        && rm -rf /tmp/* /tmp/.htaccess
+COPY --from=composer:1.7.3 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/
 COPY ./app /var/www
-RUN composer install --no-ansi --no-dev --no-interaction --no-scripts --optimize-autoloader
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,19 @@ FROM php:7.2-apache
 RUN apt-get update && apt-get install -y \
         libpng-dev \
         git subversion mercurial bash patch \
-        libzip-dev \
-        zip 
+        libzip-dev zip
 
-RUN docker-php-ext-configure zip --with-libzip
-
-RUN docker-php-ext-install pcntl gd zip \
-	&& docker-php-ext-enable pcntl gd zip
+RUN docker-php-ext-configure zip --with-libzip && \
+    docker-php-ext-install pcntl gd zip && \
+	docker-php-ext-enable pcntl gd zip
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
-ENV COMPOSER_VERSION 1.7.3
 
-COPY --from=composer:1.7.3 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+RUN usermod -u 1000 www-data
 
 WORKDIR /var/www/
 COPY ./app /var/www
-
+RUN chown -R www-data:www-data /var/www

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
 3. Lancer les tests unitaires
 
     ```
-    docker exec -it tp-poo composer test
+    docker exec tp-poo composer test
     ```
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
     docker-compose up -d
     ```
 
-2. Installer les dépendances composer
-
-    ```
-    docker exec tp-poo composer install
-    ```
-
 3. Lancer les tests unitaires
 
     ```
@@ -22,3 +16,17 @@
 
 1. `Cannot delete /some-random-folder/.git/truc.idx`
     - Solution : supprimer le dossier `vendor` et refaire la commande d'installation.
+
+## Lancement de docker sous Windows 10 Famille / Education
+
+Pré-requis : Virtualbox.
+
+1. Installer [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/)
+
+2. Installer [Git Bash](https://git-scm.com/download/win)
+
+2. Lancer Kitematic pour démarrer une machine virtuelle permettant de lancer des conteneurs.
+
+3. Lancer Git Bash
+
+4. Les commandes `docker` et `docker-compose` devraient désormais être accessible

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@
     docker exec tp-poo composer test
     ```
 
+## Potentielles erreurs
+
+1. `Cannot delete /some-random-folder/.git/truc.idx`
+    - Solution : supprimer le dossier `vendor` et refaire la commande d'installation.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # TP n°1 sur la POO avec PHP
 
-Demarrer le projet 
+1. Démarrer le projet 
 
-```
-docker-compose up -d
-```
+    ```
+    docker-compose up -d
+    ```
 
-Pour lancer les tests unitaires
-```
-docker exec -it tp-poo-tester composer test
-```
+2. Installer les dépendances composer
+
+    ```
+    docker exec tp-poo composer install
+    ```
+
+3. Lancer les tests unitaires
+
+    ```
+    docker exec -it tp-poo-tester composer test
+    ```
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
 3. Lancer les tests unitaires
 
     ```
-    docker exec -it tp-poo-tester composer test
+    docker exec -it tp-poo composer test
     ```
 

--- a/app/composer.json
+++ b/app/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "EPSIBordeaux/tp-poo",
+	"name": "epsi-bordeaux/tp-poo",
 	"description": "TP sur le cours de POO avec PHP",
 	"homepage": "https://github.com/EPSIBordeaux/tp-poo",
 	"license": "MIT",
@@ -21,7 +21,7 @@
 	],
 	"scripts": {
 		"test": [
-			"phpunit"
+			"./vendor/bin/phpunit"
 		]
 	},
 	"autoload": {

--- a/app/composer.json
+++ b/app/composer.json
@@ -1,42 +1,42 @@
 {
-	"name": "epsi-bordeaux/tp-poo",
-	"description": "TP sur le cours de POO avec PHP",
-	"homepage": "https://github.com/EPSIBordeaux/tp-poo",
-	"license": "MIT",
-	"version": "0.0.1",
-	"keywords": [
-		"POO",
-		"PHP"
-	],
-	"minimum-stability": "dev",
-	"authors": [
-		{
-			"name": "oRiamn",
-			"email": "durade.romain@gmail.com"
-		},
-        {
-            "name": "Sylvain",
-            "email": "contact@sylvainmetayer.fr"
-        }
-	],
-	"scripts": {
-		"test": [
-			"./vendor/bin/phpunit"
-		]
-	},
-	"autoload": {
-		"psr-4": {
-			"Example\\": "src/Example",
-			"Animal\\": "src/Animal",
-			"Animal\\Interfaces\\": "src/Animal/Interfaces"
-		}
-	},
-	"require": {
-		"php": "^7"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "^7.0",
-		"sempro/phpunit-pretty-print":"1.0.6",
-		"phpunit/php-invoker": "2.0.0"
-	}
+  "name": "epsi-bordeaux/tp-poo",
+  "description": "TP sur le cours de POO avec PHP",
+  "homepage": "https://github.com/EPSIBordeaux/tp-poo",
+  "license": "MIT",
+  "version": "0.0.1",
+  "keywords": [
+    "POO",
+    "PHP"
+  ],
+  "minimum-stability": "dev",
+  "authors": [
+    {
+      "name": "oRiamn",
+      "email": "durade.romain@gmail.com"
+    },
+    {
+      "name": "Sylvain",
+      "email": "contact@sylvainmetayer.fr"
+    }
+  ],
+  "scripts": {
+    "test": [
+      "phpunit"
+    ]
+  },
+  "autoload": {
+    "psr-4": {
+      "Example\\": "src/Example",
+      "Animal\\": "src/Animal",
+      "Animal\\Interfaces\\": "src/Animal/Interfaces"
+    }
+  },
+  "require": {
+    "php": "^7"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^7.0",
+    "sempro/phpunit-pretty-print": "1.0.6",
+    "phpunit/php-invoker": "2.0.0"
+  }
 }

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b03277b67ea985da0d1dca93ba15d8fb",
+    "content-hash": "1a7a248772f9f91369382980cf619b30",
     "packages": [],
     "packages-dev": [
         {
@@ -1566,8 +1566,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7",
-        "ext-gd": "*"
+        "php": "^7"
     },
     "platform-dev": []
 }

--- a/app/html/index.php
+++ b/app/html/index.php
@@ -1,13 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Neural Network - Tools</title>
+	<title>TP POO</title>
 </head>
 <body>
-<ul>
-	<li><a href="draw.php">Make exercises for your network</a></li>
-	<li><a href="trainning.php">Run trainning</a></li>
-	<li><a href="test.php">Test your network</a></li>
-</ul>
 </body>
 </html>

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-	colors="true"
-    printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter"
-	beStrictAboutTestsThatDoNotTestAnything="true"
-	beStrictAboutOutputDuringTests="true"
-	beStrictAboutChangesToGlobalState="true"
-	enforceTimeLimit="true"
-	verbose="true"
-	>
-	<testsuite name="TP POO">
-		<directory>tests</directory>
-	</testsuite>
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+        colors="true"
+        printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutChangesToGlobalState="true"
+        enforceTimeLimit="true"
+        verbose="true"
+>
+    <testsuite name="TP POO">
+        <directory>tests</directory>
+    </testsuite>
 
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">src</directory>
-		</whitelist>
-	</filter>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 
-	<php>
-		<ini name="error_reporting" value="E_ALL" />
-	</php>
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
 
 </phpunit>

--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -10,7 +10,7 @@
 	enforceTimeLimit="true"
 	verbose="true"
 	>
-	<testsuite name="PHP Neural network">
+	<testsuite name="TP POO">
 		<directory>tests</directory>
 	</testsuite>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,12 @@
 version: "3.1"
 
 services:
-  tp-poo-intaller:
-    container_name: tp-poo-intaller
+  tp-poo:
+    container_name: tp-poo
     image: tp-poo
     build:
       context: .
       dockerfile: ./Dockerfile
     volumes:
       - ./app:/var/www/
-    command: composer install --dev
-  
-  tp-poo-tester:
-    container_name: tp-poo-tester
-    image: tp-poo
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    volumes:
-      - ./app:/var/www/
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: "3.1"
 
 services:
+  tp-poo-intaller:
+    container_name: tp-poo-intaller
+    image: tp-poo
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./app:/var/www/
+    command: composer install --no-interaction --optimize-autoloader
+
   tp-poo:
     container_name: tp-poo
     image: tp-poo
@@ -9,4 +19,3 @@ services:
       dockerfile: ./Dockerfile
     volumes:
       - ./app:/var/www/
-


### PR DESCRIPTION
- Pas de shell interactif, car on ne souhaite pas interagir se connecter sur le conteneur et y garder une connexion. De plus sous windows, un shell interactif requiert une commande supplémentaire (`winpty `)
- Suppression de l'image d'installation qui tendait à ne pas installer correctement les dépendances (@oRiamn désolé, je sais pas pourquoi)
- Mise à jour du README pour pouvoir démarrer le projet
- Correction d'une erreur de signature lors de la récupération de composer. A la place, on récupère le binaire directement depuis l'image officielle de composer, comme ça, pas de soucis.
- Mise à jour du nom du composer.json pour ne plus avoir le warning lors des tests
- Mise à jour du composer.lock par rapport au composer.json
